### PR TITLE
fix: streamline package manager detection logic

### DIFF
--- a/packages/docsframe/src/commands/add.ts
+++ b/packages/docsframe/src/commands/add.ts
@@ -133,18 +133,11 @@ async function handleComponentAddition(
     if (componentData.dependencies.length > 0 && !skipDeps) {
       let command: "npm" | "pnpm";
 
-      if (
-        process.env.npm_execpath?.includes("npx") ||
-        process.argv.some((arg) => arg.includes("npx"))
-      ) {
+      const userAgent = process.env.npm_config_user_agent;
+      if (userAgent && userAgent.startsWith("npm")) {
         command = "npm";
         log.info("Detected npm as the package manager.");
-      } else if (
-        (process.env.npm_execpath?.includes("pnpm") &&
-          process.argv.includes("dlx")) ||
-        (process.argv.some((arg) => arg.includes("pnpm")) &&
-          process.argv.includes("dlx"))
-      ) {
+      } else if (userAgent && userAgent.startsWith("pnpm")) {
         command = "pnpm";
         log.info("Detected pnpm as the package manager.");
       } else {

--- a/packages/docsframe/src/commands/init.ts
+++ b/packages/docsframe/src/commands/init.ts
@@ -98,18 +98,11 @@ export const init = new Command()
 
     let command: "npm" | "pnpm";
 
-    if (
-      process.env.npm_execpath?.includes("npx") ||
-      process.argv.some((arg) => arg.includes("npx"))
-    ) {
+    const userAgent = process.env.npm_config_user_agent;
+    if (userAgent && userAgent.startsWith("npm")) {
       command = "npm";
       log.info("Detected npm as the package manager.");
-    } else if (
-      (process.env.npm_execpath?.includes("pnpm") &&
-        process.argv.includes("dlx")) ||
-      (process.argv.some((arg) => arg.includes("pnpm")) &&
-        process.argv.includes("dlx"))
-    ) {
+    } else if (userAgent && userAgent.startsWith("pnpm")) {
       command = "pnpm";
       log.info("Detected pnpm as the package manager.");
     } else {


### PR DESCRIPTION
This PR implements a fix for the detection of "pnpm dlx", which is currently not working correctly.

- Updated the logic for detecting the package manager from using `npx` and `pnpm` checks to utilizing the `npm_config_user_agent` environment variable.